### PR TITLE
Add postgres caching to store sessions in db

### DIFF
--- a/EnviroSense.Web/EnviroSense.Web.csproj
+++ b/EnviroSense.Web/EnviroSense.Web.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Evolve" Version="3.2.0" />
     <PackageReference Include="MailKit" Version="4.13.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Postgres" Version="1.0.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
   </ItemGroup>
 

--- a/EnviroSense.Web/Program.cs
+++ b/EnviroSense.Web/Program.cs
@@ -16,7 +16,14 @@ builder.Services.AddScoped<IMeasurementRepository, MeasurementRepository>();
 builder.Services.AddScoped<IMeasurementService, MeasurementService>();
 builder.Services.AddScoped<IAccountRepository, AccountRepository>();
 builder.Services.AddScoped<IAccountService, AccountService>();
-builder.Services.AddMemoryCache();
+builder.Services.AddDistributedPostgresCache(options =>
+{
+    options.ConnectionString = builder.Configuration.GetConnectionString("Default");
+    options.SchemaName = "public";
+    options.TableName = "cache";
+    options.CreateIfNotExists = true;
+    options.UseWAL = false;
+});
 builder.Services.AddSession(options =>
 {
     options.IdleTimeout = TimeSpan.FromMinutes(30);


### PR DESCRIPTION
## Description

This MR adds postgres caching to be able to store sessions inside postgres and keep sessions alive after server restart.

## Ticket
[ES-38](https://www.notion.so/Use-postgres-session-storage-24be4e38a05b80b68421d4221bb7f020)
